### PR TITLE
Bugfix for outgoing feed validation

### DIFF
--- a/TA-eclecticiq/bin/TA_eclecticiq_rh_eiq_observables.py
+++ b/TA-eclecticiq/bin/TA_eclecticiq_rh_eiq_observables.py
@@ -31,7 +31,7 @@ fields = [
         encrypted=False,
         default=None,
         validator=validator.String(
-            min_len=0,
+            min_len=1,
             max_len=8192,
         ),
     ),

--- a/TA-eclecticiq/bin/constants/messages.py
+++ b/TA-eclecticiq/bin/constants/messages.py
@@ -262,3 +262,11 @@ MIN_AND_MAX_INTERVAL = "Interval must be between 60s and 90 days."
 INTERVAL_MUST_BE_BETWEEN_MIN_AND_MAX_INTERVAL = (
     "Interval must be between 60s and 7776000s"
 )
+
+UNIQUE_VALUES_FOR_OUTGOING_FEEDS_ALLOWED = (
+    "Only unique values for outgoing-feeds are allowed."
+)
+
+MAXIMUM_FIVE_OUTGOING_FEEDS = "Maximum 5 outgoing-feeds allowed."
+START_DATE_INCORRECT = "Start date is incorrect."
+FUTURE_DATE_IS_NOT_ACCEPTABLE = "Future date is not acceptable."


### PR DESCRIPTION
1. Validate no duplicate outgoing feed allowed.
2. Validate not more than 5 outgoing feed is entered.
3. Start date should not be greater than current datetime.